### PR TITLE
Update service-providers - Remove excess comma

### DIFF
--- a/docs/03-service-providers.md
+++ b/docs/03-service-providers.md
@@ -85,7 +85,7 @@ To automatically register it with a Laravel project using Laravel’s package au
       "laravel": {
           "providers": [
               "JohnDoe\\BlogPackage\\BlogPackageServiceProvider"
-          ],
+          ]
       }
   }
 }


### PR DESCRIPTION
The extra comma causes the Composer to throw an error that it is invalid JSON. Removed to fix.