### PR TITLE
Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Contributions are highly welcomed.
 To start contributing, follow these steps:
 
 1. Fork this repository and `git clone` your version
-1. Install the dependencies (including **Vuepress**) with `npm install` (or use yarn)
-1. Edit the documentation and view the output with Vuespress using `npm run dev`
+1. Install the dependencies (including **VuePress**) with `npm install` (or use yarn)
+1. Edit the documentation and view the output with VuePress using `npm run dev`
 1. When satisfied, format your code using `npx prettier --write .`
 1. Commit your changes and submit the PR to the master branch
 


### PR DESCRIPTION
Hey @Jhnbrn90 

just noticed a typo ("Vuespress" instead of "VuePress") in the README.

Cheers,
Peter