### PR TITLE
Update 01-the-basics.md

### DIFF
--- a/docs/01-the-basics.md
+++ b/docs/01-the-basics.md
@@ -41,4 +41,4 @@ LICENSE
 composer.json
 ```
 
-In a package, all code that would live in the `app/` directory of a Laravel app, will live in the `src/` when working with a package.
+In a package, all code that would live in the `app/` directory of a Laravel app, will live in the `src/` directory when working with a package.


### PR DESCRIPTION
It seems a word was missed.

Alternatively, the 'the' could have been removed, to make it say "will live in `src/` when working with a package".