### PR TITLE
Explain api key

### DIFF
--- a/docs/04-testing.md
+++ b/docs/04-testing.md
@@ -67,6 +67,8 @@ Then, copy the following template to use an in-memory sqlite database and enable
 </phpunit>
 ```
 
+Note that a dummy `APP_KEY` is mentioned in the example above, in case your test suite uses [Laravel's encrypter](https://laravel.com/docs/8.x/encryption#using-the-encrypter). For most cases, the dummy value will be fine. However, you are free to either change this value to reflect an actual app key (of your Laravel application) or leave it off entirely if your test suite does not interact with the encrypter.
+
 ## Directory Structure
 
 To accommodate for feature and unit tests, create a `tests/` directory with a `Unit` and `Feature` subdirectory and a base `TestCase.php` file. The structure looks as follows:

--- a/docs/04-testing.md
+++ b/docs/04-testing.md
@@ -65,7 +65,6 @@ Then, copy the following template to use an in-memory sqlite database and enable
     <env name="APP_KEY" value="base64:2fl+Ktvkfl+Fuz4Qp/A75G2RTiWVA/ZoKZvp6fiiM10="/>
   </php>
 </phpunit>
-
 ```
 
 ## Directory Structure

--- a/docs/04-testing.md
+++ b/docs/04-testing.md
@@ -62,7 +62,7 @@ Then, copy the following template to use an in-memory sqlite database and enable
   </testsuites>
   <php>
     <env name="DB_CONNECTION" value="testing"/>
-    <env name="APP_KEY" value="AckfSECXIvnK5r28GVIWUAxmbBSjTsmF"/>
+    <env name="APP_KEY" value="base64:2fl+Ktvkfl+Fuz4Qp/A75G2RTiWVA/ZoKZvp6fiiM10="/>
   </php>
 </phpunit>
 


### PR DESCRIPTION
As requested from #53 this PR adds a section which explains the usage of the `APP_KEY` parameter within `phpunit.xml`. 
The original dummy key was copied from the [Orchestra Testbench Readme](https://github.com/orchestral/testbench#no-supported-encrypter-found-the-cipher-and--or-key-length-are-invalid), which has now been replaced with a randomly generated base64 app key generated with `php artisan key:generate`.

Closes #53 