### PR TITLE
fix: importing the wrong Kernel class 🐛

### DIFF
--- a/docs/11-middleware.md
+++ b/docs/11-middleware.md
@@ -177,7 +177,7 @@ If we want our capitalization check example to be applied globally, we can appen
 
 ```php
 // 'BlogPackageServiceProvider.php'
-use Illuminate\Contracts\Http\Kernel;
+use Illuminate\Foundation\Http\Kernel;
 use JohnDoe\BlogPackage\Http\Middleware\CapitalizeTitle;
 
 public function boot(Kernel $kernel)


### PR DESCRIPTION
The example is importing the following:

`use Illuminate\Contracts\Http\Kernel;`

This is wrong because it is referring to an interface and not to the `Illuminate\Foundation\Http\Kernel` class which is the one that has the 'pushMiddleware' method.