### PR TITLE
Fix Global Middleware Example

### DIFF
--- a/docs/11-middleware.md
+++ b/docs/11-middleware.md
@@ -177,7 +177,7 @@ If we want our capitalization check example to be applied globally, we can appen
 
 ```php
 // 'BlogPackageServiceProvider.php'
-use Illuminate\Foundation\Http\Kernel;
+use Illuminate\Contracts\Http\Kernel;
 use JohnDoe\BlogPackage\Http\Middleware\CapitalizeTitle;
 
 public function boot(Kernel $kernel)


### PR DESCRIPTION
When using the package in a standard Laravel application, the Kernel is overridden from the base kernel. 

Injecting the base kernel here creates a new instance instead of actually attaching the bound application Kernel.

Updated the example to inject the Kernel contract instead of the implementation.