### PR TITLE
Update testbench compatibility table

### DIFF
--- a/docs/02-development-environment.md
+++ b/docs/02-development-environment.md
@@ -191,19 +191,12 @@ The full compatibility table of the Orchestra Testbench is shown below, taken fr
 
 | Laravel | Testbench |
 | :------ | :-------- |
+| 10.x    | 8.x       |
 | 9.x     | 7.x       |
 | 8.x     | 6.x       |
 | 7.x     | 5.x       |
 | 6.x     | 4.x       |
-| 5.8.x   | 3.8.x     |
-| 5.7.x   | 3.7.x     |
-| 5.6.x   | 3.6.x     |
-| 5.5.x   | 3.5.x     |
-| 5.4.x   | 3.4.x     |
-| 5.3.x   | 3.3.x     |
-| 5.2.x   | 3.2.x     |
-| 5.1.x   | 3.1.x     |
-| 5.0.x   | 3.0.x     |
+| 5.x.x   | 3.x.x     |
 
 With Orchestra Testbench installed, you'll find a `vendor/orchestra/testbench-core` directory, containing a `laravel` and `src` directory. The `laravel` directory resembles the structure of an actual Laravel application, and the `src` directory provides the Laravel helpers that involve interaction with the project's directory structure (for example, related to file manipulation).
 


### PR DESCRIPTION
this will change the testbench compatibility table according to its [docs](https://github.com/orchestral/toolkit-docs/blob/main/src/testbench/getting-started/introduction.md)